### PR TITLE
add postgres volumes so data isnt lost when container turns off

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,12 @@ services:
             max-file: "3"
         ports:
           - '5434:5432'
+        volumes:
+          - caim_pg:/var/lib/postgresql
+          - caim_pgdata:/var/lib/postgresql/data
+
+volumes:
+  caim_pg:
+    name: "caim-pg"
+  caim_pgdata:
+    name: "caim-pg-data"


### PR DESCRIPTION
Having to remember to run `python manage.py migrate && python manage.py shell < seed.py` every restart was annoying me! This fixes that.