### PR TITLE
migrate and collectstatic on deploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN set -ex \
 
 COPY . /app
 
+RUN python /app/manage.py collectstatic && python /app/manage.py migrate
+
 EXPOSE 8000
 
 CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "caim.wsgi:application"]


### PR DESCRIPTION
AWS Apprunner just builds the container and then runs it, as far as I can tell. I *think* this will run the migrations and staticfile collection when deploying to either staging or production, but I am not 100% sure. Hard to test locally.

before running this in staging, validate that the staticfiles & database used in staging ARE NOT the production staticfiles location or database. 