### PR TITLE
Add string representation for FostererProfile

### DIFF
--- a/caim_base/models/fosterer.py
+++ b/caim_base/models/fosterer.py
@@ -116,6 +116,9 @@ class FostererLandlordContact(models.Model):
 
 
 class FostererProfile(models.Model):
+    def __str__(self) -> str:
+        return f"{self.firstname} {self.lastname}"
+
     class CategoryOfAnimals(models.TextChoices):
         ADULT_FEMALE = "ADULT_FEMALE", "Adult female"
         ADULT_MALE = "ADULT_MALE", "Adult male"


### PR DESCRIPTION
Quick fix to get the fosterer's first and last name displayed in the admin panel rather than the object.

Before:
![2023-08-23-12:44:19](https://github.com/caim-org/caim-app/assets/14955039/d968dcaa-96df-405c-a7d6-017769405c41)

After:
![2023-08-23-12:44:31](https://github.com/caim-org/caim-app/assets/14955039/813b9415-64b7-4d24-93dc-dd2157ab8a80)