### PR TITLE
Add automatic ECR deployment configuration

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,0 +1,33 @@
+name: Deploy to production
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+  ENVIRONMENT: prod
+  IMAGE_TAG: latest
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: "true"
+
+      - name: Build and push the Docker image to ECR
+        run: |
+          docker build -t $DOCKER_REGISTRY/caim-app-$ENVIRONMENT:$IMAGE_TAG .
+          docker push $DOCKER_REGISTRY/caim-app-$ENVIRONMENT:$IMAGE_TAG

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,32 @@
+name: Deploy to staging
+
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+  ENVIRONMENT: staging
+  IMAGE_TAG: latest
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: "true"
+
+      - name: Build and push the Docker image to ECR
+        run: |
+          docker build -t $DOCKER_REGISTRY/caim-app-$ENVIRONMENT:$IMAGE_TAG .
+          docker push $DOCKER_REGISTRY/caim-app-$ENVIRONMENT:$IMAGE_TAG


### PR DESCRIPTION
This automates deployment to the ECR registry via GitHub Actions, if we want that. What the workflows would look like:

1. We merge a PR into main. The "Deploy to staging" workflow runs, building the docker image and pushing it to the `caim-app-staging` repo. This way, staging would always reflect our latest work without manual intervention.
2. Once we're ready to release to production, we tag the release:
    ```
    git tag v1.0.0
    git push --tags
    ```
    The "Deploy to production" workflow runs, following the same process for the `caim-app-prod` repo.

This would require changing a few settings in this repo:

1. Add the necessary repository secrets for the workflows: `AWS_REGION` `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `DOCKER_REGISTRY`:
    ![2023-08-26-15:30:18](https://github.com/caim-org/caim-app/assets/14955039/51d19904-1ced-40fb-a582-0c0d025b9157)
2. Add a tag protection rule for the versioning pattern:
    ![2023-08-26-15:31:50](https://github.com/caim-org/caim-app/assets/14955039/28d58aae-cc81-4dd5-ade8-9d6931f804f4)


You can see the example runs in my fork:
- [Staging](https://github.com/justin-sleep/caim-app/actions/runs/5986801614/job/16240327464)
- [Prod](https://github.com/justin-sleep/caim-app/actions/runs/5986814438/job/16240352961)