### PR TITLE
[CAIM-49] Fix help/info panel mailto link

### DIFF
--- a/caim_base/templates/awg/apply/must-login.html
+++ b/caim_base/templates/awg/apply/must-login.html
@@ -24,7 +24,7 @@
 
       <div class="col-md-4">
         <div class="card">
-          <div class="card-body">Help / Info?</div>
+          <a class="card-body" href="mailto:hello@caim.org" >Help / Info?</a>
         </div>
       </div>
     </div>

--- a/caim_base/templates/awg/apply/success.html
+++ b/caim_base/templates/awg/apply/success.html
@@ -22,7 +22,7 @@
 
       <div class="col-md-4">
         <div class="card">
-          <div class="card-body">Help / Info?</div>
+          <a class="card-body" href="mailto:hello@caim.org" >Help / Info?</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Purpose

Make clicking on Help/Info panels open a contact link.

## Changes

- simple HTML change to add mailto link

## QA Notes

tested locally from `/organization/apply` page.

## Ticket

https://caimcommunity.atlassian.net/browse/CAIM-49