### PR TITLE
[CAIM-56] Indicate mandatory fields in the form

### DIFF
--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -505,6 +505,20 @@ def edit(request, stage_id):
         formsets_are_valid = True
 
         if stage_id == "pet-experience":
+            # Number of pet fields filled must be equal, or great then the listed number of pets.
+            num_of_pets = int(existing_pet_detail_formset.data['num_existing_pets'])
+            if num_of_pets:
+                for index, existing_pet_detail_form in enumerate(existing_pet_detail_formset):
+                    if index <= num_of_pets - 1:
+                        existing_pet_detail_form.full_clean()
+                        if not any(existing_pet_detail_form.cleaned_data.values()):
+                            formsets_are_valid = False
+                            messages.error(
+                                request,
+                                f"Ensure the \"Number of Pets\" ({num_of_pets}) matches the number of "
+                                f"\"Pet\" fields you have filled out."
+                            )
+
             if not existing_pet_detail_formset.is_valid():
                 formsets_are_valid = False
 
@@ -513,10 +527,38 @@ def edit(request, stage_id):
                 formsets_are_valid = False
 
         if stage_id == "household-details":
+            # Number of cohabitant fields filled must be equal, or great then the listed number of people in the
+            # home.
+            num_people_in_home = int(person_in_home_detail_formset.data['num_people_in_home'])
+            if num_people_in_home:
+                for index, person_in_home_detail_form in enumerate(person_in_home_detail_formset):
+                    if index <= num_people_in_home - 1:
+                        person_in_home_detail_form.full_clean()
+                        if not any(person_in_home_detail_form.cleaned_data.values()):
+                            formsets_are_valid = False
+                            messages.error(
+                                request,
+                                f"Ensure the number of people in your home ({num_people_in_home}) matches " \
+                                f"the number of \"Person in Home Details\" fields you have filled out."
+                            )
+
+            # Ensure if a user has selected `Rent` they must fill out rent details.
+            rent_own = person_in_home_detail_formset.data['rent_own']
+            if rent_own == FostererProfile.RentOwn.RENT:
+                if not person_in_home_detail_formset.data['rent_restrictions']:
+                    formsets_are_valid = False
+                    messages.error(request, 'Please describe any pet restrictions that are in place.')
+                if not person_in_home_detail_formset.data['landlord_contact_text']:
+                    formsets_are_valid = False
+                    messages.error(request, 'Please provide your landlord’s contact information below.')
+
             if not person_in_home_detail_formset.is_valid():
                 formsets_are_valid = False
 
         form_is_valid = form.is_valid()
+
+        if not formsets_are_valid:
+            messages.error(request, "Form is not valid due to errors.")
 
         if form_is_valid and formsets_are_valid:
             form.save()
@@ -632,8 +674,6 @@ def edit(request, stage_id):
             else:
                 return redirect(f"/fosterer/{next_stage}")
 
-        else:
-            messages.error(request, "Please correct form errors")
     else:
         form = form_class(instance=fosterer_profile)
 

--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -558,9 +558,9 @@ def edit(request, stage_id):
         form_is_valid = form.is_valid()
 
         if not formsets_are_valid:
-            messages.error(request, "Form is not valid due to errors.")
+            messages.error(request, "Please correct any form errors")
 
-        if form_is_valid and formsets_are_valid:
+        if form_is_valid:
             form.save()
 
             if stage_id == "pet-experience":


### PR DESCRIPTION
## Purpose

Provides validation and error messages for form submission with logically contradictory form details. 

## Change
<img width="961" alt="Screenshot 2023-09-03 at 2 25 55 PM" src="https://github.com/caim-org/caim-app/assets/9688518/f7bab562-c19c-4c27-9a6d-51f066d6d621">
<img width="956" alt="Screenshot 2023-09-03 at 2 26 30 PM" src="https://github.com/caim-org/caim-app/assets/9688518/941c587c-534d-4746-800d-9b8203448e31">
<img width="933" alt="Screenshot 2023-09-03 at 3 12 42 PM" src="https://github.com/caim-org/caim-app/assets/9688518/16faf198-2a10-41fb-9229-3550579fb78c">
<img width="975" alt="Screenshot 2023-09-03 at 3 13 12 PM" src="https://github.com/caim-org/caim-app/assets/9688518/fc3f77f2-3544-41a4-bedb-fe136b9408e2">

- adds logic to prevent form submission with mis-matched Pets/Household members info
- add logic to conditional rent field for rent info

## Ticket

https://caimcommunity.atlassian.net/browse/CAIM-56