### PR TITLE
resolve circular dependency in type annotations

### DIFF
--- a/caim_base/notifications.py
+++ b/caim_base/notifications.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
 from templated_email import send_templated_mail
 
-from caim_base.models.fosterer import FosterApplicationAnimalSuggestion, FosterApplication
 from django.conf import settings
+import caim_base.models.fosterer as fosterer
 
 NOTIFICATIONS_SOURCE_EMAIL = "notifications@caim.org"
 INTERNAL_NOTIFICATIONS_EMAIL = "hello@caim.org"
@@ -57,7 +58,7 @@ def notify_new_fosterer_profile(fosterer):
     )
 
 
-def notify_fosterer_of_animal_suggestion(suggested_animal: FosterApplicationAnimalSuggestion):
+def notify_fosterer_of_animal_suggestion(suggested_animal: fosterer.FosterApplicationAnimalSuggestion):
     send_templated_mail(
         template_name="application_animal_suggestion",
         from_email=NOTIFICATIONS_SOURCE_EMAIL,
@@ -68,7 +69,7 @@ def notify_fosterer_of_animal_suggestion(suggested_animal: FosterApplicationAnim
         },
     )
 
-def notify_caim_of_animal_suggestion(suggested_animal: FosterApplicationAnimalSuggestion):
+def notify_caim_of_animal_suggestion(suggested_animal: fosterer.FosterApplicationAnimalSuggestion):
     send_templated_mail(
         template_name="application_animal_suggestion_internal",
         from_email=NOTIFICATIONS_SOURCE_EMAIL,
@@ -79,7 +80,7 @@ def notify_caim_of_animal_suggestion(suggested_animal: FosterApplicationAnimalSu
         },
     )
 
-def notify_caim_foster_application_accepted(application: FosterApplication):
+def notify_caim_foster_application_accepted(application: fosterer.FosterApplication):
     send_templated_mail(
         template_name="application_accepted_internal",
         from_email=NOTIFICATIONS_SOURCE_EMAIL,
@@ -88,8 +89,8 @@ def notify_caim_foster_application_accepted(application: FosterApplication):
             "app": application,
         }
     )
-    
-def notify_caim_foster_application_rejected(application: FosterApplication):
+
+def notify_caim_foster_application_rejected(application: fosterer.FosterApplication):
     send_templated_mail(
         template_name="application_rejected_internal",
         from_email=NOTIFICATIONS_SOURCE_EMAIL,


### PR DESCRIPTION
App is throwing `ImportError: cannot import name 'FosterApplicationAnimalSuggestion' from partially initialized module 'caim_base.models.fosterer' (most likely due to a circular import) (/app/caim_base/models/fosterer.py)` on startup. Since these imports are only for type annotations, it appears we can use [PEP 563](https://peps.python.org/pep-0563/) to resolve the circular import.