### PR TITLE
[CAIM-47] #2 Remove old save search buttons

### DIFF
--- a/caim_base/templates/base/wrapper.html
+++ b/caim_base/templates/base/wrapper.html
@@ -78,13 +78,11 @@
                 <ul class="dropdown-menu dropdown-menu-end" id="userMenu">
                   <li><a class="dropdown-item" href="/user/{{request.user.username}}">My Profile</a></li>
                   <li><a class="dropdown-item" href="/browse?shortlist=on">My Favorites</a></li>
-                  <li><a class="dropdown-item" href="#">My Saved Searches</a></li>
                   <li><a class="dropdown-item" href="/my-organizations">My Organizations</a></li>
                   <li><hr class="dropdown-divider"></li>
                   <li><a class="dropdown-item" href="{% url "account_details" %}">Account Details</a></li>
                 {% comment %} This link is redundant, there's an edit button under the profile page {% endcomment %}
                 {% comment %} <li><a class="dropdown-item" href="/user/{{request.user.username}}/edit">Edit Profile</a></li> {% endcomment %}
-                  <li><a class="dropdown-item" href="#">Notification Settings</a></li>
                   <li><hr class="dropdown-divider"></li>
                   <li><a class="dropdown-item" href="/logout">Logout</a></li>
                 </ul>

--- a/caim_base/templates/browse.html
+++ b/caim_base/templates/browse.html
@@ -36,28 +36,6 @@
             {% endif %}
           </p>
         </div>
-        <div class="col-md-6 text-end d-bottom-mobile">
-          <div class="d-flex py-2 justify-content-center justify-content-md-end align-items-center">
-            <a href="#" onclick="saveSearch()" class="btn btn-secondary">Save search</a>
-
-            {% if savedSearches %}
-              <li class="dropdown">
-                <a class="dropdown-toggle" style="text-decoration: none; color:white;" data-bs-toggle="dropdown" href="#" role="button">
-                  Saved searches
-                </a>
-                <ul class="dropdown-menu dropdown-menu-end">
-                  {% for saved_search in savedSearches %}
-                    <li>
-                      <a class="dropdown-item" href="{{ saved_search.get_absolute_url }}">
-                        {{ saved_search.name }}
-                      </a>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </li>
-            {% endif %}
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -201,11 +179,8 @@
         </div>
       </div>
       <div class="col-md-9">
-
         {% include 'components/animal_list.html' %}
         {% include 'components/animal_pagination.html' %}
-        {% include 'components/saved_search_modal.html' %}
-
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Purpose

The last ticket to remove the "todo" modals, didn't go far enough in removing the whole visible button, this PR removes all traces of the save search feature.

## Change

- Removes old buttons for saved searchs

## Ticket

https://caimcommunity.atlassian.net/browse/CAIM-47