### PR TITLE
Set engineering team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @caim-org/engineers


### PR DESCRIPTION
This PR adds the @caim-org/engineers group as the CODEOWNERS of the repository. The main rationale behind adding this is to automatically request the engineers as reviewers on new PRs. The team will need to be granted write access to the repo [per the docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) before this is merged.