### PR TITLE
[CAIM-53] #2 Fix fosterers form redirect for default behavior

### DIFF
--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.forms import ModelForm, RadioSelect, formset_factory
 from django.forms.models import model_to_dict
 from django.http import Http404
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect, render, reverse
 from django.views.decorators.http import require_http_methods
 
 
@@ -433,7 +433,7 @@ STAGES = {
 @login_required()
 @require_http_methods(["GET"])
 def start(request):
-    after = request.GET.get('after')
+    after = request.GET.get('after', '')
     return redirect(f"/fosterer/about-you?after={after}")
 
 
@@ -457,7 +457,7 @@ def edit(request, stage_id):
             fosterer_profile.save()
             notify_new_fosterer_profile(fosterer_profile)
 
-        link = request.GET.get('after')
+        link = request.GET.get('after') or reverse('browse')
         return render(
             request,
             "fosterer_profile/complete.html",
@@ -667,7 +667,7 @@ def edit(request, stage_id):
                             )
 
             is_previous = "submit_prev" in request.POST
-            after = request.GET.get('after')
+            after = request.GET.get('after', '')
 
             if is_previous:
                 return redirect(f"/fosterer/{prev_stage}?after={after}")


### PR DESCRIPTION
## Purpose

Fix behavior where fosterers form redirect was causing final link to be string-ified as "None" instead of redirecting to the browse page.

## Changes

- Add simple logical fixes to cover causes when `after` is null.

## Ticket

https://caimcommunity.atlassian.net/browse/CAIM-53