### PR TITLE
[CAIM-3] refactor salesforce utils

### DIFF
--- a/caim_base/utils/salesforce.py
+++ b/caim_base/utils/salesforce.py
@@ -1,39 +1,24 @@
 from logging import getLogger
 from django.conf import settings
 from simple_salesforce import Salesforce
+from functools import cache
 
 logger = getLogger(__name__)
 
-def _user_from_form(user_form):
-    """compile user data from form into object for salesforce"""
-    form_data = user_form.cleaned_data
-
-    return {
-        "FirstName": form_data.get("first_name"),
-        "LastName": form_data.get("last_name"),
-        "Email": form_data.get("email"),
-        "MailingCity": form_data.get("city"),
-        "MailingState": form_data.get("state"),
-        "MailingPostalCode": form_data.get("zip_code"),
-    }
-
-
+@cache
 def _salesforce_connection():
     """create salesforce connection with auth"""
-
     return Salesforce(
         username=settings.SALESFORCE_USERNAME,
         password=settings.SALESFORCE_PASSWORD,
         security_token=settings.SALESFORCE_SECURITY_TOKEN,
     )
 
-
-def create_contact(user_profile, user_form):
+def _create_contact(user_profile, user_form, connection = _salesforce_connection()):
     logger.info("Enter create contact")
-    sf = _salesforce_connection()
     sf_user = _user_from_form(user_form)
 
-    result = sf.Contact.create(sf_user)
+    result = connection.Contact.create(sf_user)
 
     errors = result.get(
         "errors",
@@ -55,14 +40,36 @@ def create_contact(user_profile, user_form):
         logger.info("Salesforce id not found")
         return
 
-
-def update_contact(salesforce_id, user_form):
-    sf = _salesforce_connection()
+def _update_contact(salesforce_id, user_form, connection = _salesforce_connection()):
     sf_user = _user_from_form(user_form)
 
     try:
         # 204 (no content) results from successful update
         # exceptions thrown on failure
-        sf.Contact.update(salesforce_id, sf_user)
+        connection.Contact.update(salesforce_id, sf_user)
     except Exception:
         logger.exception("Not able to update contact")
+
+
+def _user_from_form(user_form):
+    """compile user data from form into object for salesforce"""
+    form_data = user_form.cleaned_data
+
+    return {
+        "FirstName": form_data.get("first_name"),
+        "LastName": form_data.get("last_name"),
+        "Email": form_data.get("email"),
+        "MailingCity": form_data.get("city"),
+        "MailingState": form_data.get("state"),
+        "MailingPostalCode": form_data.get("zip_code"),
+    }
+
+def create_or_update_contact(user_profile, user_form):
+    if not settings.SALESFORCE_ENABLED:
+        logger.info("Salesforce not enabled for this environment, skipping")
+        return
+
+    if user_profile.salesforce_id is not None:
+        _update_contact(user_profile.salesforce_id, user_form)
+    else:
+        _create_contact(user_profile, user_form)

--- a/caim_base/views/account_details.py
+++ b/caim_base/views/account_details.py
@@ -61,12 +61,7 @@ def edit(request: HttpRequest) -> HttpResponse:
             user_profile.zip_code = form.cleaned_data["zip_code"]
             user_profile.save()
 
-            # create or update salesforce contact
-            if settings.SALESFORCE_ENABLED:
-                if user_profile.salesforce_id is not None:
-                    salesforce.update_contact(user_profile.salesforce_id, form)
-                else:
-                    salesforce.create_contact(user_profile, form)
+            salesforce.create_or_update_contact(user_profile, form)
 
             return redirect("account_details")
 

--- a/caim_base/views/auth.py
+++ b/caim_base/views/auth.py
@@ -54,9 +54,7 @@ def register_view(request):
             )
             user_profile.save()
 
-            # create contact in salesforce
-            if settings.SALESFORCE_ENABLED:
-                salesforce.create_contact(user_profile, form)
+            salesforce.create_or_update_contact(user_profile, form)
 
             login(request, user)
             messages.success(request, "Registration successful.")


### PR DESCRIPTION
minor refactors to the salesforce code to improve ergonomics and efficiency

- rather than determining whether salesforce is enabled at the calling site, handle this check within the salesforce code
- rather than determining whether a contact exists at the calling site, handle this check within the salesforce code
- don't create a new Salesforce object for every call. `salesforce-simple` brings [its own mechanism](https://github.com/simple-salesforce/simple-salesforce/blob/master/simple_salesforce/api.py#L276) for refreshing stale sessions.