### PR TITLE
styles(awg-applications): Update accept/reject modals to more closely match mocks

### DIFF
--- a/caim_base/static/css/modals.css
+++ b/caim_base/static/css/modals.css
@@ -1,0 +1,33 @@
+.modal-body {
+    /* padding: 50px 50px; */
+}
+
+.applicant-modal-header {
+    padding: 20px 24px 0;
+}
+
+.close-button {
+    width: 24px;
+    height: 24px;
+}
+.picture-preview-container {
+    width: 34px;
+    height: 34px;
+}
+
+.picture-preview {
+    object-fit: contain;
+    padding: 0;
+}
+
+.entity-overview {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.fake-profile-image {
+    background-color: #D9D9D9;
+    clip-path: circle();
+}

--- a/caim_base/static/css/styles.css
+++ b/caim_base/static/css/styles.css
@@ -1,3 +1,5 @@
+@import "modals.css";
+
 /* @todo move into static asset */
 .page-narrow .container {
     max-width: 1024px;

--- a/caim_base/templates/awg/manage/applications/accept_modal.html
+++ b/caim_base/templates/awg/manage/applications/accept_modal.html
@@ -22,7 +22,6 @@
           <div class="row py-2">
             <div class="col text-center entity-overview">
               <div class="row fs-7 pb-2">Applicant</div>
-
               <div class="row picture-preview-container fake-profile-image"></div>
               <div class="row fs-7 pt-2">{{ app.fosterer.firstname }} {{ app.fosterer.lastname }}</div>
               <div class="row text-secondary fs-7">{{ app.fosterer.city }}, {{ app.fosterer.state }}</div>
@@ -39,12 +38,12 @@
               <div class="row fs-7 pt-2">{{ app.animal.name}}</div>
               <div class="row text-secondary fs-7">{{ app.animal.awg.city}}, {{ app.animal.awg.state }}</div>
             </div>
-            <form class="pt-3 d-flex justify-content-center" action="/organization/{{ awg.id }}/applications/{{ app.id }}" , method="post">
+            <form class="pt-4 d-flex justify-content-center" action="/organization/{{ awg.id }}/applications/{{ app.id }}" , method="post">
               {% csrf_token %}
               <input class="d-none" name="status" type="text" value="{{ app.Statuses.ACCEPTED | title }}"
                      readonly>
               <button
-                class="btn btn-primary"
+                class="btn btn-primary btn-lg"
                 hx-post="{% url 'awg_update_application_status_submit_modal' awg_id=awg.id application_id=app.id %}"
                 hx-target="#awg-applications-modal"
                 _="on htmx:afterOnLoad wait 10ms then add .show to #modal then add .show to #modal-backdrop"

--- a/caim_base/templates/awg/manage/applications/accept_modal.html
+++ b/caim_base/templates/awg/manage/applications/accept_modal.html
@@ -2,37 +2,44 @@
 {% load static %}
 <div id="modal-backdrop" class="modal-backdrop fade show" style="display:block;"></div>
 <div id="modal" class="modal fade show" tabindex="-1" style="display:block;">
-  <div class="modal-dialog modal-xl modal-dialog-centered">
+  <div class="modal-dialog modal-fullscreen-sm-down modal-xl modal-dialog-centered">
     <div class="modal-content">
-      <div class="modal-header">
+      <div class="applicant-modal-header">
+        <div class="d-flex justify-content-end">
+          <i class="bi-x" style="font-size: 2rem; cursor: pointer;" onclick="closeModal('awg-applications-modal')"></i>
+        </div>
         <div class="container-fluid" style="height: 100%;">
           <img
             class="mx-auto d-block"
             src="{% static 'img/thinking.svg' %}"
           >
-          <div class="fs-3 text-center">Are you sure you want to accept this application?</div>
+          <div class="pt-5 fs-3 fw-bold text-center">Are you sure you want to approve this application?</div>
         </div>
       </div>
       <div class="modal-body">
         <div class="container-fluid">
-          <div class="row">
-            <div class="col text-center">
-              <h4 class="row">Applicant</h4>
-              <div class="row">{{ app.fosterer.firstname }} {{ app.fosterer.lastname }}</div>
-              <div>{{ app.fosterer.city }}, {{ app.fosterer.state }}</div>
+          <div class="fs-5 py-3 text-center">Please review all the details below</div>
+          <div class="row py-2">
+            <div class="col text-center entity-overview">
+              <div class="row fs-7 pb-2">Applicant</div>
+
+              <div class="row picture-preview-container fake-profile-image"></div>
+              <div class="row fs-7 pt-2">{{ app.fosterer.firstname }} {{ app.fosterer.lastname }}</div>
+              <div class="row text-secondary fs-7">{{ app.fosterer.city }}, {{ app.fosterer.state }}</div>
             </div>
-            <div class="col text-center">
-              <h4 class="row">Animal</h4>
-              <div class="row">
+            <div class="col text-center entity-overview row-gap-3">
+              <div class="row fs-7 pb-2">Animal</div>
+              <div class="row picture-preview-container">
                 <img
-                  class="col"
+                  class="col picture-preview"
                   style="background-color: #eee; clip-path: circle()"
-                  src="{{ app.animal.primary_photo.url|image_resize:'75x75 crop' }}"
+                  src="{{ app.animal.primary_photo.url|image_resize:'34x34' }}"
                 >
-                <div class="col">{{ app.animal.name}}</div>
               </div>
+              <div class="row fs-7 pt-2">{{ app.animal.name}}</div>
+              <div class="row text-secondary fs-7">{{ app.animal.awg.city}}, {{ app.animal.awg.state }}</div>
             </div>
-            <form action="/organization/{{ awg.id }}/applications/{{ app.id }}" , method="post">
+            <form class="pt-3 d-flex justify-content-center" action="/organization/{{ awg.id }}/applications/{{ app.id }}" , method="post">
               {% csrf_token %}
               <input class="d-none" name="status" type="text" value="{{ app.Statuses.ACCEPTED | title }}"
                      readonly>
@@ -41,9 +48,9 @@
                 hx-post="{% url 'awg_update_application_status_submit_modal' awg_id=awg.id application_id=app.id %}"
                 hx-target="#awg-applications-modal"
                 _="on htmx:afterOnLoad wait 10ms then add .show to #modal then add .show to #modal-backdrop"
-              >Confirm</button>
+              >Continue</button>
             </form>
-            <button type="button" class="btn btn-link" onclick="closeModal('awg-applications-modal')">cancel</button>
+            <button type="button" class="btn btn-link text-decoration-none" onclick="closeModal('awg-applications-modal')">cancel</button>
           </div>
         </div>
       </div>

--- a/caim_base/templates/awg/manage/applications/reject_modal.html
+++ b/caim_base/templates/awg/manage/applications/reject_modal.html
@@ -2,43 +2,49 @@
 {% load caim_helpers %}
 <div id="modal-backdrop" class="modal-backdrop fade show" style="display:block;"></div>
 <div id="modal" class="modal fade show" tabindex="-1" style="display:block;">
-  <div class="modal-dialog modal-xl modal-dialog-centered">
+  <div class="modal-dialog modal-fullscreen-sm-down modal-xl modal-dialog-centered">
     <div class="modal-content">
-      <div class="modal-header">
+      <div class="applicant-modal-header">
+        <div class="d-flex justify-content-end">
+          <i class="bi-x" style="font-size: 2rem; cursor: pointer;" onclick="closeModal('awg-applications-modal')"></i>
+        </div>
         <div class="container-fluid" style="height: 100%;">
           <img
             class="mx-auto d-block"
             src="{% static 'img/thinking.svg' %}"
           >
-          <div class="fs-3 text-center">Are you sure you want to reject this application?</div>
+          <div class="pt-5 fs-3 fw-bold text-center">Are you sure you want to reject this application?</div>
         </div>
       </div>
       <div class="modal-body">
         <div class="container-fluid">
-          <div class="row">
-            <div class="col text-start">
-              <h4 class="row">Applicant</h4>
-              <div class="row">{{ app.fosterer.firstname }} {{ app.fosterer.lastname }}</div>
-              <div>{{ app.fosterer.city }}, {{ app.fosterer.state }}</div>
+          <div class="row py-2">
+            <div class="col text-center entity-overview">
+              <h4 class="row fs-7 pb-2">Applicant</h4>
+              <div class="row picture-preview-container fake-profile-image"></div>
+              <div class="row fs-7 pt-2">{{ app.fosterer.firstname }} {{ app.fosterer.lastname }}</div>
+              <div class="row text-secondary fs-7">{{ app.fosterer.city }}, {{ app.fosterer.state }}</div>
             </div>
-            <div class="col text-end">
-              <h4 class="row justify-content-end">Animal</h4>
-              <div class="row justify-content-center">
+            <div class="col text-center entity-overview">
+              <h4 class="row fs-7 pb-2">Animal</h4>
+              <div class="row picture-preview-container">
                 <img
-                  class="row"
+                  class="col picture-preview"
                   style="background-color: #eee; clip-path: circle()"
-                  src="{{ app.animal.primary_photo.url|image_resize:'75x75 crop' }}"
+                  src="{{ app.animal.primary_photo.url|image_resize:'34x34' }}"
                 >
-                <div class="row justify-content-center">{{ app.animal.name}}</div>
               </div>
+              <div class="row fs-7 pt-2">{{ app.animal.name}}</div>
+              <div class="row text-secondary fs-7">{{ app.animal.awg.city}}, {{ app.animal.awg.state }}</div>
             </div>
-            <form action="/organization/{{ awg.id }}/applications/{{ app.id }}", method="post" style="height: 100%;">
+          </div>
+            <form class="pt-3" action="/organization/{{ awg.id }}/applications/{{ app.id }}", method="post" style="height: 100%;">
               {% csrf_token %}
               <input class="d-none" name="status" type="text" value="{{ app.Statuses.REJECTED | title }}" readonly>
-              <div class="row justify-content-start align-content-start text-start" style="height: 50%;">
-                <div>Select the reason for rejection</div>
-                <div class="input-group" style="height: 25%;">
-                  <select class="form-control" name="reject_reason">
+              <div class="row d-flex justify-content-center flex-column justify-content-start align-content-start text-center" style="height: 50%;">
+                <div class="fs-6 py-3">Select the reason for rejection</div>
+                <div class="input-group py-2" style="height: 25%;">
+                  <select class="form-control row" name="reject_reason">
                     <option
                       value=""
                     >
@@ -53,7 +59,7 @@
                     {% endfor %}
                   </select>
                 </div>
-                <div class="input-group" style="height: 75%;">
+                <div class="input-group py-2" style="height: 75%;">
                   <textarea
                     name='reject_reason_detail'
                     class="form-control row"
@@ -62,15 +68,19 @@
                   ></textarea>
                 </div>
               </div>
-              <button
-                class="btn btn-primary"
-                hx-post="{% url 'awg_update_application_status_submit_modal' awg_id=awg.id application_id=app.id %}"
-                hx-target="#awg-applications-modal"
-                _="on htmx:afterOnLoad wait 10ms then add .show to #modal then add .show to #modal-backdrop"
-              >Confirm</button>
+              <div class="d-flex justify-content-center py-4">
+                <button
+                  class="btn btn-primary btn-lg"
+                  hx-post="{% url 'awg_update_application_status_submit_modal' awg_id=awg.id application_id=app.id %}"
+                  hx-target="#awg-applications-modal"
+                  _="on htmx:afterOnLoad wait 10ms then add .show to #modal then add .show to #modal-backdrop"
+                >Reject</button>
+              </div>
             </form>
-            <button type="button" class="btn btn-link" onclick="closeModal('awg-applications-modal')">cancel</button>
-          </div>
+
+            <div class="d-flex justify-content-center">
+              <button type="button py-2" class="btn btn-link text-decoration-none" onclick="closeModal('awg-applications-modal')">cancel</button>
+            </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**status**: ready for review
**mock**: [figma link](https://www.figma.com/file/RukqZBUSK7dJdTvgxKIhwa/Caim---Webapp?type=design&node-id=54-752&mode=design&t=AJp5zHCYofugKyXs-0)

# Changes
* Add a modal css file for some of the more repeated styles/styles that are too cumbersome to do all in bootstrap
* Update styles padding/arrangement to match the mocks
* Make the modal fullscreen on mobile 
  * note: currently the mocks have a different "close" for mobile, however haven't been able to dig deep enough to make this work (probably will have to do a secondary pass with some elements that get `display: none` depending on the breakpoints for mobile)

# Screenshots
## accept modal
### desktop
![image](https://github.com/caim-org/caim-app/assets/6327663/a9186b8d-c7f6-4cc9-84d9-72b7d340f2b5)

### mobile
![image](https://github.com/caim-org/caim-app/assets/6327663/3416ac0b-e1b6-48e7-8ca4-11fbd33949fb)
## reject modal
### desktop
![image](https://github.com/caim-org/caim-app/assets/6327663/5b53b911-4fcb-4567-88c7-d584b3d4752b)

### mobile
![image](https://github.com/caim-org/caim-app/assets/6327663/2bba1857-a998-4cbd-86be-9092068f1014)
