### PR TITLE
[CAIM-3] don't pass user form to salesforce utils; track FosterProfile status in Salesforce

### DIFF
--- a/caim_base/utils/salesforce.py
+++ b/caim_base/utils/salesforce.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
 from logging import getLogger
+from functools import cache
 from django.conf import settings
 from simple_salesforce import Salesforce
-from functools import cache
+from .. import models
 
 logger = getLogger(__name__)
 
@@ -14,11 +16,10 @@ def _salesforce_connection():
         security_token=settings.SALESFORCE_SECURITY_TOKEN,
     )
 
-def _create_contact(user_profile, user_form, connection):
+def _create_contact(salesforce_contact, connection):
     logger.info("Enter create contact")
-    sf_user = _user_from_form(user_form)
 
-    result = connection.Contact.create(sf_user)
+    result = connection.Contact.create(salesforce_contact)
 
     errors = result.get(
         "errors",
@@ -31,22 +32,13 @@ def _create_contact(user_profile, user_form, connection):
         return
 
     salesforce_id = result.get("id")
-    if salesforce_id:
-        # update profile with salesforce id
-        user_profile.salesforce_id = salesforce_id
-        user_profile.save()
+    return salesforce_id
 
-    else:
-        logger.info("Salesforce id not found")
-        return
-
-def _update_contact(salesforce_id, user_form, connection):
-    sf_user = _user_from_form(user_form)
-
+def _update_contact(salesforce_id, salesforce_contact, connection):
     try:
         # 204 (no content) results from successful update
         # exceptions thrown on failure
-        connection.Contact.update(salesforce_id, sf_user)
+        connection.Contact.update(salesforce_id, salesforce_contact)
     except Exception:
         logger.exception("Not able to update contact")
 
@@ -64,12 +56,31 @@ def _user_from_form(user_form):
         "MailingPostalCode": form_data.get("zip_code"),
     }
 
-def create_or_update_contact(user_profile, user_form):
+def _user_profile_to_salesforce_contact(user_profile: UserProfile):
+    return {
+        "FirstName": user_profile.user.first_name,
+        "LastName": user_profile.user.last_name,
+        "Email": user_profile.user.email,
+        "MailingCity": user_profile.city,
+        "MailingState": user_profile.state,
+        "MailingPostalCode": user_profile.zip_code,
+    }
+
+
+def create_or_update_contact(user_profile: models.UserProfile):
     if not settings.SALESFORCE_ENABLED:
         logger.info("Salesforce not enabled for this environment, skipping")
         return
 
+    salesforce_contact = _user_profile_to_salesforce_contact(user_profile)
+
     if user_profile.salesforce_id is not None:
-        _update_contact(user_profile.salesforce_id, user_form, _salesforce_connection())
+        _update_contact(user_profile.salesforce_id, salesforce_contact, _salesforce_connection())
     else:
-        _create_contact(user_profile, user_form, _salesforce_connection())
+        logger.info("salesforce_id is not present, creating new contact")
+        salesforce_id = _create_contact(salesforce_contact, _salesforce_connection())
+        if salesforce_id:
+            logger.info("salesforce id created")
+            # update profile with salesforce id
+            user_profile.salesforce_id = salesforce_id
+            user_profile.save()

--- a/caim_base/views/account_details.py
+++ b/caim_base/views/account_details.py
@@ -61,7 +61,7 @@ def edit(request: HttpRequest) -> HttpResponse:
             user_profile.zip_code = form.cleaned_data["zip_code"]
             user_profile.save()
 
-            salesforce.create_or_update_contact(user_profile, form)
+            salesforce.create_or_update_contact(user_profile)
 
             return redirect("account_details")
 

--- a/caim_base/views/auth.py
+++ b/caim_base/views/auth.py
@@ -8,7 +8,6 @@ from ..forms import NewUserForm
 from ..models import UserProfile, FostererProfile
 from ..utils import salesforce
 
-
 def login_view(request):
     if request.method == "POST":
         form = AuthenticationForm(request, data=request.POST)
@@ -54,7 +53,7 @@ def register_view(request):
             )
             user_profile.save()
 
-            salesforce.create_or_update_contact(user_profile, form)
+            salesforce.create_or_update_contact(user_profile)
 
             login(request, user)
             messages.success(request, "Registration successful.")

--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -18,6 +18,7 @@ from ..models import (
 from ..models.fosterer import FostererProfile
 from ..models.user import UserProfile
 from ..notifications import notify_new_fosterer_profile
+from ..utils import salesforce
 
 
 class ExistingPetDetailForm(forms.ModelForm):
@@ -429,13 +430,11 @@ STAGES = {
     },
 }
 
-
 @login_required()
 @require_http_methods(["GET"])
 def start(request):
     after = request.GET.get('after', '')
     return redirect(f"/fosterer/about-you?after={after}")
-
 
 @login_required()
 @require_http_methods(["POST", "GET"])
@@ -455,6 +454,7 @@ def edit(request, stage_id):
             # @todo check if all fields done
             fosterer_profile.is_complete = True
             fosterer_profile.save()
+            salesforce.update_fosterer_profile_complete(user)
             notify_new_fosterer_profile(fosterer_profile)
 
         link = request.GET.get('after') or reverse('browse')


### PR DESCRIPTION
- we currently use a mix of the form details and user profile object in the salesforce utils, which turns out to be redundant. this change updates the functions so that the form no longer needs to get passed.
- adds FosterProfile status to the salesforce contact. this status is initialized as incomplete when a contact is created and updated when the fosterer_profile form is completed. Values are defined by the salesforce contact definition 
<img width="423" alt="image" src="https://github.com/caim-org/caim-app/assets/1026445/9e9b9fa2-5133-4024-a16c-fbed4a91b64e">
