### PR TITLE
[CAIM-75] Add "Read more" button to animal cards

### DIFF
--- a/caim_base/static/css/styles.css
+++ b/caim_base/static/css/styles.css
@@ -1,5 +1,11 @@
 @import "modals.css";
 
+/* custom properties */
+:root {
+    --main-color: #37CABA;
+}
+
+
 /* @todo move into static asset */
 .page-narrow .container {
     max-width: 1024px;
@@ -30,17 +36,17 @@ h2,
 h3,
 h4,
 h5 {
-    color: #37CABA;
+    color: var(--main-color);
 }
 
 a {
-    color: #37CABA;
+    color: var(--main-color);
 
 }
 
 .btn-primary {
     color: white;
-    background: #37CABA;
+    background: var(--main-color);
 }
 
 .btn {
@@ -89,7 +95,7 @@ input.text {
 
 .animal-card:hover {
     cursor: pointer;
-    border: 3px solid #37CABA;
+    border: 3px solid var(--main-color);
     padding: 0px;
 }
 
@@ -135,6 +141,11 @@ input.text {
 
 .btn {
     padding: 0.375rem 1.5rem;
+}
+
+
+.btn-link {
+    color: var(--main-color);
 }
 
 .asteriskField {
@@ -199,7 +210,7 @@ legend {
 }
 
 .animal-shortlist-selected {
-    background: #37CABA;
+    background: var(--main-color);
     color: white;
 }
 

--- a/caim_base/templates/animal/view.html
+++ b/caim_base/templates/animal/view.html
@@ -138,9 +138,12 @@
                   <div>{{ animal.is_vaccinations_current | yesno | capfirst }}</div>
                 </div>
                 {% if animal.vaccinations_notes %}
-                  <p>
-                    {{ animal.vaccinations_notes | urlizetrunc:60 | linebreaks }}
-                  </p>
+                  <div class="d-inline-block">
+                    {{ animal.vaccinations_notes | truncatechars:150 | linebreaksbr }}
+                    {% if animal.vaccinations_notes|length > 150 %}
+                      <button class="btn btn-link text-decoration-none align-top p-0" onclick="this.parentElement.innerHTML = '{{ animal.vaccinations_notes | linebreaksbr }}'">Read more</button>
+                    {% endif %}
+                  </div>
                 {% endif %}
                 <div class="d-flex justify-content-between">
                   <div>
@@ -150,9 +153,12 @@
                   <div>{{ animal.is_special_needs | yesno | capfirst }}</div>
                 </div>
                 {% if animal.special_needs %}
-                  <p>
-                    {{ animal.special_needs | urlizetrunc:60 | linebreaks }}
-                  </p>
+                  <div class="d-inline-block">
+                    {{ animal.special_needs | truncatechars:150 | linebreaksbr }}
+                    {% if animal.special_needs|length > 150 %}
+                      <button class="btn btn-link text-decoration-none align-top p-0" onclick="this.parentElement.innerHTML = '{{ animal.special_needs| linebreaksbr }}'">Read more</button>
+                    {% endif %}
+                  </div>
                 {% endif %}
               </div>
             </div>


### PR DESCRIPTION
This adds a "Read more" button to the longer text fields on the animal cards. If the text is longer than 150 characters, it's truncated and the button is shown.

![2023-09-25-12:36:44](https://github.com/caim-org/caim-app/assets/14955039/3ec23392-b548-44ea-a49f-f1fdb9fccc8a)
