### PR TITLE
logging - use the ext:// prefix for accessing stdout

### DIFF
--- a/caim/settings.py
+++ b/caim/settings.py
@@ -205,7 +205,7 @@ LOGGING = {
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
-            "stream": sys.stdout,
+            "stream": "ext://sys.stdout",
         }
     },
     "root": {


### PR DESCRIPTION
I followed the wrong tutorial and accidentally added the literal import for `sys.stdout` instead of the `ext://`-prefixed string described in [the official documentation](https://docs.python.org/3/library/logging.config.html#access-to-external-objects).