### PR TITLE
[CAIM-56] Add landlord contact info and fix rent validation

### DIFF
--- a/caim_base/admin.py
+++ b/caim_base/admin.py
@@ -13,7 +13,7 @@ from .models.animals import (
     User,
 )
 from .models.awg import AwgMember
-from .models.fosterer import FostererProfile, FosterApplication, FostererReferenceDetail
+from .models.fosterer import FostererProfile, FosterApplication, FostererReferenceDetail, FostererLandlordContact
 from .models.user import UserProfile
 
 # Unregister the user admin so we can user our own
@@ -78,6 +78,10 @@ class ReferenceInline(admin.TabularInline):
     model = FostererReferenceDetail
 
 
+class LandlordContactInline(admin.TabularInline):
+    model = FostererLandlordContact
+
+
 class CommentAdmin(admin.ModelAdmin):
     inlines = [SubCommentInline]
 
@@ -94,7 +98,7 @@ class FostererProfileAdmin(admin.ModelAdmin):
             and not x.system_check_deprecated_details
         ]
 
-    inlines = [ReferenceInline]
+    inlines = [ReferenceInline, LandlordContactInline]
 
 
 admin.site.register(Breed)

--- a/caim_base/admin.py
+++ b/caim_base/admin.py
@@ -13,7 +13,12 @@ from .models.animals import (
     User,
 )
 from .models.awg import AwgMember
-from .models.fosterer import FostererProfile, FosterApplication, FostererReferenceDetail, FostererLandlordContact
+from .models.fosterer import (
+    FostererProfile,
+    FosterApplication,
+    FostererReferenceDetail,
+    FostererLandlordContact,
+)
 from .models.user import UserProfile
 
 # Unregister the user admin so we can user our own

--- a/caim_base/models/fosterer.py
+++ b/caim_base/models/fosterer.py
@@ -416,7 +416,8 @@ class FostererProfile(models.Model):
         ),
     )
     landlord_contact_text.system_check_deprecated_details = {
-        "msg": "The ReferenceDetail1 field has been deprecated, use FostererLandlordContact instead",
+        "msg": "The ReferenceDetail1 field has been deprecated, "
+        "use FostererLandlordContact instead"
     }
 
     hours_alone_description = models.TextField(

--- a/caim_base/models/fosterer.py
+++ b/caim_base/models/fosterer.py
@@ -415,6 +415,10 @@ class FostererProfile(models.Model):
             " We will contact them to confirm that you have approval to foster."
         ),
     )
+    landlord_contact_text.system_check_deprecated_details = {
+        "msg": "The ReferenceDetail1 field has been deprecated, use FostererLandlordContact instead",
+    }
+
     hours_alone_description = models.TextField(
         blank=True,
         null=True,

--- a/caim_base/templates/fosterer_profile/edit.html
+++ b/caim_base/templates/fosterer_profile/edit.html
@@ -178,6 +178,10 @@
             asterisk.textContent = '*';
             asterisk.style.color = 'red';
             document.querySelector('#div_id_rent_restrictions>label').append(asterisk);
+            document.querySelector('#div_id_landlord_first_name>label').append(asterisk.cloneNode(true));
+            document.querySelector('#div_id_landlord_last_name>label').append(asterisk.cloneNode(true));
+            document.querySelector('#div_id_landlord_phone>label').append(asterisk.cloneNode(true));
+            document.querySelector('#div_id_landlord_email>label').append(asterisk.cloneNode(true));
 
             function toggleRentRestrictions() {
                 var rented = document.querySelector('#id_rent_own_0');

--- a/caim_base/templates/fosterer_profile/edit.html
+++ b/caim_base/templates/fosterer_profile/edit.html
@@ -168,6 +168,20 @@
             var rentRestrictionsInput =  document.querySelector('#div_id_rent_restrictions');
             var landlordContactText =  document.querySelector('#div_id_landlord_contact_text');
 
+
+            // Append the asterisk to make conditional form logic work
+            var asterisk = document.createElement('label');
+            asterisk.textContent = '*';
+            asterisk.style.color = 'red';
+            document.querySelector('#div_id_rent_restrictions>label').append(asterisk);
+
+            // Append the asterisk to make conditional form logic work
+            var asterisk = document.createElement('label');
+            asterisk.textContent = '*';
+            asterisk.style.color = 'red';
+            document.querySelector('#div_id_landlord_contact_text>label').append(asterisk);
+
+
             function toggleRentRestrictions() {
                 var rented = document.querySelector('#id_rent_own_0');
                 var owned = document.querySelector('#id_rent_own_1');

--- a/caim_base/templates/fosterer_profile/edit.html
+++ b/caim_base/templates/fosterer_profile/edit.html
@@ -134,78 +134,77 @@
       </div>
     </div>
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+      document.addEventListener('DOMContentLoaded', function() {
+        function updateDetailsVisibility(inputSelector, detailSelector) {
+          var numInput = document.querySelector(inputSelector);
+          var details = document.querySelectorAll(detailSelector);
 
-            function updateDetailsVisibility(inputSelector, detailSelector) {
-                var numInput = document.querySelector(inputSelector);
-                var details = document.querySelectorAll(detailSelector);
+          function setVisibility() {
+            var num = parseInt(numInput.value);
 
-                function setVisibility() {
-                    var num = parseInt(numInput.value);
-
-                    // Iterate through all details and show/hide based on num value
-                    for(var i = 0; i < details.length; i++) {
-                        if(i < num) {
-                            details[i].style.display = '';
-                        } else {
-                            details[i].style.display = 'none';
-                        }
-                    }
-                }
-
-                if(numInput) {
-                    // Initial setup
-                    setVisibility();
-                    // Listen to the change event
-                    numInput.addEventListener('change', setVisibility);
-                }
+            // Iterate through all details and show/hide based on num value
+            for(var i = 0; i < details.length; i++) {
+              if(i < num) {
+                details[i].style.display = '';
+              } else {
+                details[i].style.display = 'none';
+              }
             }
+          }
 
-            // Initialize for Pets and People in Home
-            updateDetailsVisibility('[name="num_existing_pets"]', '.pet-detail');
-            updateDetailsVisibility('[name="num_people_in_home"]', '.person-detail');
+          if(numInput) {
+            // Initial setup
+            setVisibility();
+            // Listen to the change event
+            numInput.addEventListener('change', setVisibility);
+          }
+        }
 
-            // Make rent specific fields disappear for homeowners
-            var rentRestrictionsInput =  document.querySelector('#div_id_rent_restrictions');
-            var landlordFirstName =  document.querySelector('#div_id_landlord_first_name');
-            var landlordLastName =  document.querySelector('#div_id_landlord_last_name');
-            var landlordPhone =  document.querySelector('#div_id_landlord_phone');
-            var landlordEmail =  document.querySelector('#div_id_landlord_email');
+        // Initialize for Pets and People in Home
+        updateDetailsVisibility('[name="num_existing_pets"]', '.pet-detail');
+        updateDetailsVisibility('[name="num_people_in_home"]', '.person-detail');
+
+        // Make rent specific fields disappear for homeowners
+        var rentRestrictionsInput =  document.querySelector('#div_id_rent_restrictions');
+        var landlordFirstName =  document.querySelector('#div_id_landlord_first_name');
+        var landlordLastName =  document.querySelector('#div_id_landlord_last_name');
+        var landlordPhone =  document.querySelector('#div_id_landlord_phone');
+        var landlordEmail =  document.querySelector('#div_id_landlord_email');
 
 
-            // Append the asterisk to make conditional form logic work
-            var asterisk = document.createElement('label');
-            asterisk.textContent = '*';
-            asterisk.style.color = 'red';
-            document.querySelector('#div_id_rent_restrictions>label').append(asterisk);
-            document.querySelector('#div_id_landlord_first_name>label').append(asterisk.cloneNode(true));
-            document.querySelector('#div_id_landlord_last_name>label').append(asterisk.cloneNode(true));
-            document.querySelector('#div_id_landlord_phone>label').append(asterisk.cloneNode(true));
-            document.querySelector('#div_id_landlord_email>label').append(asterisk.cloneNode(true));
+        // Append the asterisk to make conditional form logic work
+        var asterisk = document.createElement('label');
+        asterisk.textContent = '*';
+        asterisk.style.color = 'red';
+        document.querySelector('#div_id_rent_restrictions>label').append(asterisk);
+        document.querySelector('#div_id_landlord_first_name>label').append(asterisk.cloneNode(true));
+        document.querySelector('#div_id_landlord_last_name>label').append(asterisk.cloneNode(true));
+        document.querySelector('#div_id_landlord_phone>label').append(asterisk.cloneNode(true));
+        document.querySelector('#div_id_landlord_email>label').append(asterisk.cloneNode(true));
 
-            function toggleRentRestrictions() {
-                var rented = document.querySelector('#id_rent_own_0');
-                var owned = document.querySelector('#id_rent_own_1');
-                if(rented.checked) {
-                    rentRestrictionsInput.style.display = 'block';
-                    landlordFirstName.style.display = 'block';
-                    landlordLastName.style.display = 'block';
-                    landlordPhone.style.display = 'block';
-                    landlordEmail.style.display = 'block';
-                } else {
-                    rentRestrictionsInput.style.display = 'none';
-                    landlordFirstName.style.display = 'none';
-                    landlordLastName.style.display = 'none';
-                    landlordEmail.style.display = 'none';
-                    landlordPhone.style.display = 'none';
-                }
-            }
-            var rentInput = document.querySelector('#id_rent_own_0');
-            var ownedInput = document.querySelector('#id_rent_own_1');
+        function toggleRentRestrictions() {
+          var rented = document.querySelector('#id_rent_own_0');
+          var owned = document.querySelector('#id_rent_own_1');
+          if(rented.checked) {
+            rentRestrictionsInput.style.display = 'block';
+            landlordFirstName.style.display = 'block';
+            landlordLastName.style.display = 'block';
+            landlordPhone.style.display = 'block';
+            landlordEmail.style.display = 'block';
+          } else {
+            rentRestrictionsInput.style.display = 'none';
+            landlordFirstName.style.display = 'none';
+            landlordLastName.style.display = 'none';
+            landlordEmail.style.display = 'none';
+            landlordPhone.style.display = 'none';
+          }
+        }
+        var rentInput = document.querySelector('#id_rent_own_0');
+        var ownedInput = document.querySelector('#id_rent_own_1');
 
-            rentInput.addEventListener('change', toggleRentRestrictions);
-            ownedInput.addEventListener('change', toggleRentRestrictions);
-            toggleRentRestrictions();
-        });
+        rentInput.addEventListener('change', toggleRentRestrictions);
+        ownedInput.addEventListener('change', toggleRentRestrictions);
+        toggleRentRestrictions();
+      });
     </script>
 {% endblock %}

--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -380,13 +380,6 @@ class FostererProfileStage5Form(ModelForm):
             "yard_fence_over_5ft": RadioSelect(),
             "rent_own": RadioSelect(),
         }
-        labels = {
-            "landlord_first_name": 'Landlord\'s First Name',
-            "landlord_last_name": 'Landlord\'s Last Name',
-            "landlord_email": 'Landlord\'s Email Contact',
-            "landlord_phone": 'Landlord\'s Phone',
-
-        }
 
 
 class FostererProfileStage6Form(ModelForm):
@@ -610,25 +603,25 @@ def edit(request, stage_id):
                     formsets_are_valid = False
                     messages.error(
                         request,
-                        "Please add your landlord\'s phone contact.",
+                        "Please add your landlord's phone contact.",
                     )
                 if not person_in_home_detail_formset.data["landlord_first_name"]:
                     formsets_are_valid = False
                     messages.error(
                         request,
-                        "Please add your landlord\'s first name.",
+                        "Please add your landlord's first name.",
                     )
                 if not person_in_home_detail_formset.data["landlord_last_name"]:
                     formsets_are_valid = False
                     messages.error(
                         request,
-                        "Please add your landlord\'s last name.",
+                        "Please add your landlord's last name.",
                     )
                 if not person_in_home_detail_formset.data["landlord_email"]:
                     formsets_are_valid = False
                     messages.error(
                         request,
-                        "Please add your landlord\'s email.",
+                        "Please add your landlord's email.",
                     )
 
         form_is_valid = form.is_valid()
@@ -726,7 +719,10 @@ def edit(request, stage_id):
                 existing_household_members = FostererPersonInHomeDetail.objects.filter(
                     fosterer_profile=fosterer_profile
                 ).order_by("id")
-                landlord_details, created = FostererLandlordContact.objects.get_or_create(
+                (
+                    landlord_details,
+                    created,
+                ) = FostererLandlordContact.objects.get_or_create(
                     fosterer_profile=fosterer_profile
                 )
                 form_data = form.data
@@ -736,7 +732,6 @@ def edit(request, stage_id):
                 landlord_details.phone = form_data.get("landlord_phone")
 
                 landlord_details.save()
-
 
                 for index, detail_form in enumerate(person_in_home_detail_formset):
                     if detail_form.is_valid() and detail_form.has_changed():
@@ -766,7 +761,9 @@ def edit(request, stage_id):
                 return redirect(f"/fosterer/{next_stage}?after={after}")
 
     else:
-        landlord_details, created = FostererLandlordContact.objects.get_or_create(fosterer_profile=fosterer_profile)
+        landlord_details, created = FostererLandlordContact.objects.get_or_create(
+            fosterer_profile=fosterer_profile
+        )
         form = form_class(
             instance=fosterer_profile,
             initial={
@@ -774,7 +771,7 @@ def edit(request, stage_id):
                 "landlord_last_name": landlord_details.last_name,
                 "landlord_email": landlord_details.email,
                 "landlord_phone": landlord_details.phone,
-            }
+            },
         )
         existing_pets = FostererExistingPetDetail.objects.filter(
             fosterer_profile=fosterer_profile

--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -538,8 +538,7 @@ def edit(request, stage_id):
                                 f"\"Pet Details\" sections you entirely have filled out."
                             )
                             break
-
-            if not existing_pet_detail_formset.is_valid():
+            else:
                 formsets_are_valid = False
 
         if stage_id == "references":
@@ -554,8 +553,7 @@ def edit(request, stage_id):
                 for index, person_in_home_detail_form in enumerate(person_in_home_detail_formset):
                     if index < num_people_in_home:
                         person_in_home_detail_form.full_clean()
-                        any_missing_fields = not all(value is not None for value in person_in_home_detail_form.cleaned_data.values())
-                        if not person_in_home_detail_form.cleaned_data or any_missing_fields:
+                        if not person_in_home_detail_form.is_valid():
                             formsets_are_valid = False
                             messages.error(
                                 request,
@@ -563,7 +561,8 @@ def edit(request, stage_id):
                                 f"the number of \"Person in Home Details\" sections you have entirely filled out."
                             )
                             break
-
+            else:
+                formsets_are_valid = False
             # Ensure if a user has selected `Rent` they must fill out rent details.
             rent_own = person_in_home_detail_formset.data['rent_own']
             if rent_own == FostererProfile.RentOwn.RENT:
@@ -573,9 +572,6 @@ def edit(request, stage_id):
                 if not person_in_home_detail_formset.data['landlord_contact_text']:
                     formsets_are_valid = False
                     messages.error(request, 'Please provide your landlord’s contact information below.')
-
-            if not person_in_home_detail_formset.is_valid():
-                formsets_are_valid = False
 
         form_is_valid = form.is_valid()
 

--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -117,9 +117,10 @@ class FostererProfileStage1Form(ModelForm):
         fosterer_profile: FostererProfile | None = kwargs.get("instance")
         if fosterer_profile:
             user = fosterer_profile.user
-            user_profile = FostererProfile.objects.get(user=user)
+            user_profile = UserProfile.objects.filter(user=user)
 
             if user_profile is not None:
+                user_profile = user_profile.get()
                 if not fosterer_profile.firstname:
                     initial_args["firstname"] = user.first_name
                 if not fosterer_profile.lastname:

--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -582,24 +582,21 @@ def edit(request, stage_id):
             num_people_in_home = int(
                 person_in_home_detail_formset.data["num_people_in_home"]
             )
-            if num_people_in_home:
-                for index, person_in_home_detail_form in enumerate(
-                    person_in_home_detail_formset
-                ):
-                    if index < num_people_in_home:
-                        person_in_home_detail_form.full_clean()
-                        if not person_in_home_detail_form.is_valid():
-                            formsets_are_valid = False
-                            messages.error(
-                                request,
-                                f"Ensure the number of people in your home "
-                                f"({num_people_in_home}) matches the number of "
-                                f'"Person in Home Details" sections you have '
-                                f"entirely filled out.",
-                            )
-                            break
-            else:
-                formsets_are_valid = False
+            for index, person_in_home_detail_form in enumerate(
+                person_in_home_detail_formset
+            ):
+                if index < num_people_in_home:
+                    person_in_home_detail_form.full_clean()
+                    if not person_in_home_detail_form.is_valid():
+                        formsets_are_valid = False
+                        messages.error(
+                            request,
+                            f"Ensure the number of people in your home "
+                            f"({num_people_in_home}) matches the number of "
+                            f'"Person in Home Details" sections you have '
+                            f"entirely filled out.",
+                        )
+                        break
             # Ensure if a user has selected `Rent` they must fill out rent details.
             rent_own = person_in_home_detail_formset.data["rent_own"]
             if rent_own == FostererProfile.RentOwn.RENT:

--- a/caim_base/views/fosterer_profile.py
+++ b/caim_base/views/fosterer_profile.py
@@ -117,7 +117,7 @@ class FostererProfileStage1Form(ModelForm):
         fosterer_profile: FostererProfile | None = kwargs.get("instance")
         if fosterer_profile:
             user = fosterer_profile.user
-            user_profile = UserProfile.objects.get(user=user)
+            user_profile = FostererProfile.objects.get(user=user)
 
             if user_profile is not None:
                 if not fosterer_profile.firstname:
@@ -540,30 +540,18 @@ def edit(request, stage_id):
             # Number of pet fields filled must be
             # equal or greater then the listed number of pets.
             num_of_pets = int(existing_pet_detail_formset.data["num_existing_pets"])
-            if num_of_pets:
-                for index, existing_pet_detail_form in enumerate(
-                    existing_pet_detail_formset
-                ):
-                    if index < num_of_pets:
-                        existing_pet_detail_form.full_clean()
-                        any_missing_fields = not all(
-                            value is not None
-                            for value in existing_pet_detail_form.cleaned_data.values()
-                        )
-                        if (
-                            not existing_pet_detail_form.cleaned_data
-                            or any_missing_fields
-                        ):
-                            formsets_are_valid = False
-                            messages.error(
-                                request,
-                                f'Ensure the "Number of Pets" ({num_of_pets}) matches '
-                                f'the number of "Pet Details" sections you have '
-                                f"entirely filled out.",
-                            )
-                            break
-            else:
-                formsets_are_valid = False
+            for index, existing_pet_detail_form in enumerate(
+                existing_pet_detail_formset
+            ):
+                if index < num_of_pets and not existing_pet_detail_form.is_valid():
+                    formsets_are_valid = False
+                    messages.error(
+                        request,
+                        f'Ensure the "Number of Pets" ({num_of_pets}) matches '
+                        f'the number of "Pet Details" sections you have '
+                        f"entirely filled out.",
+                    )
+                    break
 
         if stage_id == "references":
             if not reference_detail_formset.is_valid():


### PR DESCRIPTION
## Purpose

Fix issue with rent/ownership form validation and split landlord contacts into multiple fields.

## Changes

- fixes rent validation logic
- adds required elements in JS
- add new landlord contact CRUD
- add new landlord contact to admin app
<img width="1043" alt="Screenshot 2023-10-09 at 11 13 05 AM" src="https://github.com/caim-org/caim-app/assets/9688518/5e1d7863-64e7-4a69-929c-2b3113a4c528">

*admin app*
<img width="1024" alt="Screenshot 2023-10-09 at 11 18 53 AM" src="https://github.com/caim-org/caim-app/assets/9688518/83888e29-cff2-4719-9648-a17d260f9368">

## Ticket

https://caimcommunity.atlassian.net/browse/CAIM-56